### PR TITLE
Feathers mongoose clean up

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,40 @@
+module.exports = {
+  "env": {
+    "node": true,
+    "es6": true
+  },
+  "rules": {
+    "camelcase": 1,
+    "complexity": [2, 5],
+    "comma-spacing": 1,
+    "consistent-return": 0,
+    "eol-last": 1,
+    "eqeqeq": [2, "smart"],
+    "indent": [1, 2],
+    "max-depth": [1, 2],
+    "max-len": [2, 100],
+    "max-nested-callbacks": [1, 1],
+    "max-params": [1, 4],
+    "max-statements": [1, 15],
+    "no-use-before-define": [2, "nofunc"],
+    "no-multi-spaces": 1,
+    "no-process-exit": 0,
+    "no-trailing-spaces": 1,
+    "no-underscore-dangle": 0,
+    "no-unused-vars": 1,
+    "space-infix-ops": 1,
+    "quotes": [1, "single"],
+    "semi": [1, "always"],
+    "semi-spacing": 1,
+    "strict": [2, "global"],
+    "yoda": [1, "never"]
+  },
+  "globals": {
+    "describe": true,
+    "it": true,
+    "before": true,
+    "beforeEach": true,
+    "after": true,
+    "afterEach": true
+  }
+};

--- a/src/app.js
+++ b/src/app.js
@@ -2,15 +2,38 @@
 
 const feathers = require('@feathersjs/feathers');
 const express = require('@feathersjs/express');
-const Animals = require('./services/animals.js');
 const app = express(feathers());
+const mongoose = require('mongoose');
+const service = require('feathers-mongoose');
+const animalsModel = require('./models/animals.js');
 
-app.configure(express.rest());
+mongoose.Promise = global.Promise;
 
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-app.use('animals', new Animals());
-app.use(express.errorHandler());
+app
+  .configure(express.rest())
+  .use(express.json())
+  .use(express.urlencoded({ extended: true }))
+  .use('/animals', service({
+    Model: animalsModel,
+    lean: true, // set to false if you want Mongoose documents returned
+    paginate: {
+      default: 2,
+      max: 4
+    }
+  }))
+  .use(express.errorHandler());
+
+
+mongoose
+  .connect('mongodb://localhost:27017', {
+    dbName: "adopteitor"
+  })
+  .then((res) => {
+    console.log("[mongoose.connected]");
+  })
+  .catch((err) => {
+    console.log("[mongoose.connection failed]", err);
+  });
 
 const server = app.listen(3030);
 

--- a/src/app.js
+++ b/src/app.js
@@ -36,4 +36,7 @@ mongoose
 
 const server = app.listen(3030);
 
-server.on('listening', () => console.log('Adopteitor Server started at http://localhost:3030'));
+server.on('listening', () => {
+  process.stdout.write("\u001b[2J\u001b[0;0H"); // This is for clearing the console.
+  console.log('Adopteitor Server started at http://localhost:3030')
+});

--- a/src/app.js
+++ b/src/app.js
@@ -23,16 +23,15 @@ app
   }))
   .use(express.errorHandler());
 
-
 mongoose
   .connect('mongodb://localhost:27017', {
-    dbName: "adopteitor"
+    dbName: 'adopteitor'
   })
-  .then((res) => {
-    console.log("[mongoose.connected]");
+  .then(() => {
+    console.log('[mongoose.connected]');
   })
   .catch((err) => {
-    console.log("[mongoose.connection failed]", err);
+    console.log('[mongoose.connection failed]', err);
   });
 
 const server = app.listen(3030);

--- a/src/app.js
+++ b/src/app.js
@@ -4,11 +4,6 @@ const feathers = require('@feathersjs/feathers');
 const express = require('@feathersjs/express');
 const Animals = require('./services/animals.js');
 const app = express(feathers());
-const mongoose = require('mongoose');
-const service = require('feathers-mongoose');
-
-mongoose.Promise = global.Promise;
-// mongoose.connect('mongodb://localhost:27017/feathers');
 
 app.configure(express.rest());
 

--- a/src/models/animals.js
+++ b/src/models/animals.js
@@ -3,11 +3,7 @@
 const mongoose = require('mongoose');
 
 const Schema = mongoose.Schema;
-const AnimalsSchema = new Schema({
-  _id: {
-    type: Number,
-    required: true
-  },
+const AnimalSchema = new Schema({
   stage: {
     type: String,
     required: true

--- a/src/models/animals.js
+++ b/src/models/animals.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const mongoose = require('mongoose');
-
 const Schema = mongoose.Schema;
-const AnimalSchema = new Schema({
+const AnimalsSchema = new Schema({
   stage: {
     type: String,
     required: true

--- a/src/models/contracts.js
+++ b/src/models/contracts.js
@@ -1,21 +1,18 @@
 'use strict';
 
 const mongoose = require('mongoose');
-
-const Schema = mongoose.Schema,
-      ObjectId = Schema.ObjectId;
-
+const Schema = mongoose.Schema;
 const ContractsSchema = new Schema({
   _id: {
     type: Number,
     required: true
   },
   animalId: {
-    type: ObjectId,
+    type: Schema.ObjectId,
     required: true
   },
   humanId: {
-    type: ObjectId,
+    type: Schema.ObjectId,
     required: true
   },
   createdAt: {

--- a/src/models/humans.js
+++ b/src/models/humans.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const mongoose = require('mongoose');
-
 const Schema = mongoose.Schema;
 const HumansSchema = new Schema({
   _id: {

--- a/src/services/animals.js
+++ b/src/services/animals.js
@@ -1,4 +1,6 @@
 const AnimalModel = require('../models/animals');
+const mongoose = require('mongoose');
+const service = require('feathers-mongoose');
 
 class Animals {
   constructor() {
@@ -22,18 +24,35 @@ class Animals {
   }
 
   async create(data, params) {
-    const AnimalData = {
+    const Model = require('../models/animal');
+    let AnimalData = {
       stage: data.stage,
       name: data.name,
       dateOfBirth: data.dateOfBirth,
       description: data.description,
       entryDate: data.entryDate
     };
-
     const animal = new AnimalModel(AnimalData);
-    
-    this.animals.push(animal); // TODO persist to DB here 
 
+    this.animals.push(animal);
+    mongoose.Promise = global.Promise;
+    mongoose
+      .connect('mongodb://localhost:27017', {
+        dbName: "adopteitor"
+      })
+        .then((res) => {
+          animal.save((err) => {
+            console.log("[animal.save] err", err);
+          })
+          console.log("[RES]");
+          console.log(res);
+          console.log("[RES]");
+        })
+        .catch((err) => {
+          console.log("[ERR]");
+          console.log(err);
+          console.log("[ERR]");
+        });
     return this.animal;
   }
 

--- a/src/services/animals.js
+++ b/src/services/animals.js
@@ -1,82 +1,64 @@
-const AnimalModel = require('../models/animals');
-const mongoose = require('mongoose');
-const service = require('feathers-mongoose');
-
-class Animals {
-  constructor() {
-    this.animals = [];
-    this.currentId = 0;
-  }
-
-  async find(params) {
-    // Return the list of all animals
-    return this.animals;
-  }
-
-  async get(id, params) {
-    const animal = this.animals.find(animal => animal.id === parseInt(id, 10));
-    // Throw an error if it wasn't found
-    if(!animal) {
-      throw new Error(`animal with id ${id} not found`);
-    }
-    // Otherwise return the animal
-    return animal;
-  }
-
-  async create(data, params) {
-    const Model = require('../models/animal');
-    let AnimalData = {
-      stage: data.stage,
-      name: data.name,
-      dateOfBirth: data.dateOfBirth,
-      description: data.description,
-      entryDate: data.entryDate
-    };
-    const animal = new AnimalModel(AnimalData);
-
-    this.animals.push(animal);
-    mongoose.Promise = global.Promise;
-    mongoose
-      .connect('mongodb://localhost:27017', {
-        dbName: "adopteitor"
-      })
-        .then((res) => {
-          animal.save((err) => {
-            console.log("[animal.save] err", err);
-          })
-          console.log("[RES]");
-          console.log(res);
-          console.log("[RES]");
-        })
-        .catch((err) => {
-          console.log("[ERR]");
-          console.log(err);
-          console.log("[ERR]");
-        });
-    return this.animal;
-  }
-
-  async patch(id, data, params) {
-    // Get the existing animal. Will throw an error if not found
-    const animal = await this.get(id);
-
-    // Merge the existing animal with the new data
-    // and return the result
-    return Object.assign(animal, data);
-  }
-
-  async remove(id, params) {
-    // Get the animal by id (will throw an error if not found)
-    const animal = await this.get(id);
-    // Find the index of the animal in our animal array
-    const index = this.animals.indexOf(animal);
-
-    // Remove the found animal from our array
-    this.animals.splice(index, 1);
-
-    // Return the removed animal
-    return animal;
-  }
-}
-
-module.exports = Animals;
+// const AnimalModel = require('../models/animals');
+// const mongoose = require('mongoose');
+//
+// class Animals {
+//   constructor() {
+//     this.animals = [];
+//     this.currentId = 0;
+//   }
+//
+//   async find(params) {
+//     // Return the list of all animals
+//     return this.animals;
+//   }
+//
+//   async get(id, params) {
+//     const animal = this.animals.find(animal => animal.id === parseInt(id, 10));
+//     // Throw an error if it wasn't found
+//     if(!animal) {
+//       throw new Error(`animal with id ${id} not found`);
+//     }
+//     // Otherwise return the animal
+//     return animal;
+//   }
+//
+//   async create(data, params) {
+//     const AnimalData = {
+//       stage: data.stage,
+//       name: data.name,
+//       dateOfBirth: data.dateOfBirth,
+//       description: data.description,
+//       entryDate: data.entryDate
+//     };
+//     const animal = new AnimalModel(AnimalData);
+//
+//     animal.save((err) => {
+//       console.log("[animal.save] err", err);
+//     })
+//     return this.animal;
+//   }
+//
+//   async patch(id, data, params) {
+//     // Get the existing animal. Will throw an error if not found
+//     const animal = await this.get(id);
+//
+//     // Merge the existing animal with the new data
+//     // and return the result
+//     return Object.assign(animal, data);
+//   }
+//
+//   async remove(id, params) {
+//     // Get the animal by id (will throw an error if not found)
+//     const animal = await this.get(id);
+//     // Find the index of the animal in our animal array
+//     const index = this.animals.indexOf(animal);
+//
+//     // Remove the found animal from our array
+//     this.animals.splice(index, 1);
+//
+//     // Return the removed animal
+//     return animal;
+//   }
+// }
+//
+// module.exports = Animals;


### PR DESCRIPTION
We are not using anymore the animals service. Instead we are using feathers-mongoose to create a new service, passing the model and we get back a fully functional endpoint.

This is the request im using to exercise the endpoint:

POST /animals HTTP/1.1
Host: localhost:3030
Content-Type: application/json
Cache-Control: no-cache
Postman-Token: ee9a757f-aaf4-0b80-a8ee-c96d18e34141

{
	"stage": "_stage_",
	"name": "_name_",
	"dateOfBirth": "2/2/2010",
	"description": "_desc_",
	"entryDate": "6/6/2020"
}

In order to test this, you need to have mongo up and running, with an "adopteitor" database and a "animals" table.

We can remove animals/service.js. SHould we?